### PR TITLE
Core features

### DIFF
--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -7,7 +7,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject.transform);
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject);
 			behaviour.Initialize();
 			return behaviour;
 		}
@@ -15,7 +15,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject.transform);
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
@@ -23,7 +23,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChildFromResources<TBehaviour>(this GameObject gameObject, string path, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject.transform, worldPositionStay);
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
 			behaviour.Initialize();
 			return behaviour;
 		}
@@ -31,7 +31,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChildFromResources<TBehaviour, TArgs>(this GameObject gameObject, string path, TArgs args, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject.transform, worldPositionStay);
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
@@ -39,7 +39,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChildFromLoaded<TBehaviour>(this GameObject gameObject, TBehaviour behaviourToClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject.transform);
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
 			behaviour.Initialize();
 			return behaviour;
 		}
@@ -47,7 +47,7 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour CreateChildFromLoaded<TBehaviour, TArgs>(this GameObject gameObject, TBehaviour behaviourToClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject.transform);
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
 			behaviour.Initialize(args);
 			return behaviour;
 		}

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -1,0 +1,109 @@
+﻿using UnityEngine;
+
+namespace DUCK.HieriarchyBehaviour
+{
+	public static class GameObjectExtensions
+	{
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject.transform);
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, TArgs args)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject.transform);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+
+		public static TBehaviour CreateChildFromResources<TBehaviour>(this GameObject gameObject, string path, bool worldPositionStay = true)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject.transform, worldPositionStay);
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour CreateChildFromResources<TBehaviour, TArgs>(this GameObject gameObject, string path, TArgs args, bool worldPositionStay = true)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject.transform, worldPositionStay);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+
+		public static TBehaviour CreateChildFromLoaded<TBehaviour>(this GameObject gameObject, TBehaviour behaviourToClone)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject.transform);
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour CreateChildFromLoaded<TBehaviour, TArgs>(this GameObject gameObject, TBehaviour behaviourToClone, TArgs args)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject.transform);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = gameObject.CreateChild<TBehaviour>();
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TArgs args)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = gameObject.CreateChild<TBehaviour, TArgs>(args);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, string path)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = gameObject.CreateChildFromResources<TBehaviour>(path);
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = gameObject.CreateChildFromResources<TBehaviour, TArgs>(path, args);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = Utils.CloneBehaviour(toClone, gameObject.transform);
+			behaviour.Initialize();
+			return behaviour;
+		}
+
+		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
+			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		{
+			Object.Destroy(toDestroy.gameObject);
+			var behaviour = Utils.CloneBehaviour(toClone, gameObject.transform);
+			behaviour.Initialize(args);
+			return behaviour;
+		}
+	}
+}

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -55,42 +55,42 @@ namespace DUCK.HieriarchyBehaviour
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour>();
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour, TArgs>(args);
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour>(path);
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, string path, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour, TArgs>(path, args);
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild(toClone);
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			Object.Destroy(toDestroy.gameObject);
+			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild(toClone, args);
 		}
 	}

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -36,18 +36,18 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, TBehaviour behaviourToClone)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, parent);
+			var behaviour = Utils.CloneBehaviour(toClone, parent);
 			behaviour.Initialize();
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TBehaviour behaviourToClone, TArgs args)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, parent);
+			var behaviour = Utils.CloneBehaviour(toClone, parent);
 			behaviour.Initialize(args);
 			return behaviour;
 		}

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -66,18 +66,18 @@ namespace DUCK.HieriarchyBehaviour
 			return parent.CreateChild<TBehaviour, TArgs>(args);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path, bool worldPositionStays = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour>(path);
+			return parent.CreateChild<TBehaviour>(path, worldPositionStays);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, string path, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, string path, TArgs args, bool worldPositionStays = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour, TArgs>(path, args);
+			return parent.CreateChild<TBehaviour, TArgs>(path, args, worldPositionStays);
 		}
 
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone)

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -20,7 +20,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChildFromResources<TBehaviour>(this GameObject gameObject, string path, bool worldPositionStay = true)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject, string path, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
@@ -28,7 +28,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChildFromResources<TBehaviour, TArgs>(this GameObject gameObject, string path, TArgs args, bool worldPositionStay = true)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, string path, TArgs args, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
@@ -36,7 +36,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChildFromLoaded<TBehaviour>(this GameObject gameObject, TBehaviour behaviourToClone)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject, TBehaviour behaviourToClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
@@ -44,7 +44,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChildFromLoaded<TBehaviour, TArgs>(this GameObject gameObject, TBehaviour behaviourToClone, TArgs args)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, TBehaviour behaviourToClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
@@ -70,28 +70,28 @@ namespace DUCK.HieriarchyBehaviour
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChildFromResources<TBehaviour>(path);
+			return gameObject.CreateChild<TBehaviour>(path);
 		}
 
 		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChildFromResources<TBehaviour, TArgs>(path, args);
+			return gameObject.CreateChild<TBehaviour, TArgs>(path, args);
 		}
 
 		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChildFromLoaded(toClone);
+			return gameObject.CreateChild(toClone);
 		}
 
 		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChildFromLoaded(toClone, args);
+			return gameObject.CreateChild(toClone, args);
 		}
 	}
 }

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -52,42 +52,42 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
 			return gameObject.CreateChild<TBehaviour>();
 		}
 
-		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
 			return gameObject.CreateChild<TBehaviour, TArgs>(args);
 		}
 
-		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, string path)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, string path)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
 			return gameObject.CreateChild<TBehaviour>(path);
 		}
 
-		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
 			return gameObject.CreateChild<TBehaviour, TArgs>(path, args);
 		}
 
-		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
 			return gameObject.CreateChild(toClone);
 		}
 
-		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -4,94 +4,94 @@ namespace DUCK.HieriarchyBehaviour
 {
 	public static class GameObjectExtensions
 	{
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject);
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(parent);
 			behaviour.Initialize();
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, TArgs args)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(gameObject);
+			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(parent);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject, string path, bool worldPositionStay = true)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, string path, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, parent, worldPositionStay);
 			behaviour.Initialize();
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, string path, TArgs args, bool worldPositionStay = true)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, string path, TArgs args, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, gameObject, worldPositionStay);
+			var behaviour = Utils.InstantiateResource<TBehaviour>(path, parent, worldPositionStay);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject gameObject, TBehaviour behaviourToClone)
+		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, TBehaviour behaviourToClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, parent);
 			behaviour.Initialize();
 			return behaviour;
 		}
 
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject gameObject, TBehaviour behaviourToClone, TArgs args)
+		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TBehaviour behaviourToClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CloneBehaviour(behaviourToClone, gameObject);
+			var behaviour = Utils.CloneBehaviour(behaviourToClone, parent);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild<TBehaviour>();
+			return parent.CreateChild<TBehaviour>();
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild<TBehaviour, TArgs>(args);
+			return parent.CreateChild<TBehaviour, TArgs>(args);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, string path)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild<TBehaviour>(path);
+			return parent.CreateChild<TBehaviour>(path);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, string path, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild<TBehaviour, TArgs>(path, args);
+			return parent.CreateChild<TBehaviour, TArgs>(path, args);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
+		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild(toClone);
+			return parent.CreateChild(toClone);
 		}
 
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
+		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			return gameObject.CreateChild(toClone, args);
+			return parent.CreateChild(toClone, args);
 		}
 	}
 }

--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -56,54 +56,42 @@ namespace DUCK.HieriarchyBehaviour
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = gameObject.CreateChild<TBehaviour>();
-			behaviour.Initialize();
-			return behaviour;
+			return gameObject.CreateChild<TBehaviour>();
 		}
 
 		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = gameObject.CreateChild<TBehaviour, TArgs>(args);
-			behaviour.Initialize(args);
-			return behaviour;
+			return gameObject.CreateChild<TBehaviour, TArgs>(args);
 		}
 
 		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, string path)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = gameObject.CreateChildFromResources<TBehaviour>(path);
-			behaviour.Initialize();
-			return behaviour;
+			return gameObject.CreateChildFromResources<TBehaviour>(path);
 		}
 
 		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, string path, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = gameObject.CreateChildFromResources<TBehaviour, TArgs>(path, args);
-			behaviour.Initialize(args);
-			return behaviour;
+			return gameObject.CreateChildFromResources<TBehaviour, TArgs>(path, args);
 		}
 
 		public static TBehaviour Replace<TBehaviour>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = Utils.CloneBehaviour(toClone, gameObject.transform);
-			behaviour.Initialize();
-			return behaviour;
+			return gameObject.CreateChildFromLoaded(toClone);
 		}
 
 		public static TBehaviour Replace<TBehaviour, TArgs>(this GameObject gameObject, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
 			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
 		{
 			Object.Destroy(toDestroy.gameObject);
-			var behaviour = Utils.CloneBehaviour(toClone, gameObject.transform);
-			behaviour.Initialize(args);
-			return behaviour;
+			return gameObject.CreateChildFromLoaded(toClone, args);
 		}
 	}
 }

--- a/GameObjectExtensions.cs.meta
+++ b/GameObjectExtensions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c54abd6fa103f40288af93eb9a77202d
+timeCreated: 1528118410
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HierarchyBehaviour.asmdef
+++ b/HierarchyBehaviour.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "HierarchyBehaviour"
+}

--- a/HierarchyBehaviour.asmdef.meta
+++ b/HierarchyBehaviour.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9aaae7f48c2df4798b4ae69ba7a8e533
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IHierarchyBehaviour.cs
+++ b/IHierarchyBehaviour.cs
@@ -1,0 +1,12 @@
+﻿namespace DUCK.HieriarchyBehaviour
+{
+	public interface IHierarchyBehaviour<TArgs>
+	{
+		void Initialize(TArgs args);
+	}
+
+	public interface IHierarchyBehaviour
+	{
+		void Initialize();
+	}
+}

--- a/IHierarchyBehaviour.cs.meta
+++ b/IHierarchyBehaviour.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c26a4bd40212446f3ad8cf15eb4597ae
+timeCreated: 1528118446
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+
+namespace DUCK.HieriarchyBehaviour
+{
+	internal static class Utils
+	{
+		internal static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, Transform parent)
+			where TBehaviour : MonoBehaviour
+		{
+			var behaviour = Object.Instantiate(behaviourToClone, parent);
+			behaviour.name = behaviourToClone.name;
+			behaviour.transform.localPosition = Vector3.zero;
+			return behaviour;
+		}
+
+		internal static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(Transform parent)
+			where TBehaviour : MonoBehaviour
+		{
+			var behaviour = new GameObject(typeof(TBehaviour).Name).AddComponent<TBehaviour>();
+			behaviour.transform.SetParent(parent.transform);
+			behaviour.transform.localPosition = Vector3.zero;
+			return behaviour;
+		}
+
+		internal static TBehaviour InstantiateResource<TBehaviour>(string path, Transform parent, bool worldPositionStay = true)
+			where TBehaviour : MonoBehaviour
+		{
+			var loadedBehaviour = Resources.Load<TBehaviour>(path);
+			var behaviour = Object.Instantiate(loadedBehaviour, parent, worldPositionStay);
+			behaviour.name = loadedBehaviour.name;
+			return behaviour;
+		}
+	}
+}

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DUCK.HieriarchyBehaviour
 {
@@ -29,6 +31,23 @@ namespace DUCK.HieriarchyBehaviour
 			var behaviour = Object.Instantiate(loadedBehaviour, parent.transform, worldPositionStay);
 			behaviour.name = loadedBehaviour.name;
 			return behaviour;
+		}
+
+		internal static void DestroyChild(GameObject parent, MonoBehaviour child)
+		{
+			if (child.transform.parent != parent)
+			{
+				throw new ArgumentException(string.Format("{0} is not a child transform of {1}", child.name, parent.name));
+			}
+
+			if (Application.isEditor)
+			{
+				Object.DestroyImmediate(child.gameObject);
+			}
+			else
+			{
+				Object.Destroy(child.gameObject);
+			}
 		}
 	}
 }

--- a/Utils.cs
+++ b/Utils.cs
@@ -4,16 +4,16 @@ namespace DUCK.HieriarchyBehaviour
 {
 	internal static class Utils
 	{
-		internal static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, Transform parent)
+		internal static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, GameObject parent)
 			where TBehaviour : MonoBehaviour
 		{
-			var behaviour = Object.Instantiate(behaviourToClone, parent);
+			var behaviour = Object.Instantiate(behaviourToClone, parent.transform);
 			behaviour.name = behaviourToClone.name;
 			behaviour.transform.localPosition = Vector3.zero;
 			return behaviour;
 		}
 
-		internal static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(Transform parent)
+		internal static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(GameObject parent)
 			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = new GameObject(typeof(TBehaviour).Name).AddComponent<TBehaviour>();
@@ -22,11 +22,11 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		internal static TBehaviour InstantiateResource<TBehaviour>(string path, Transform parent, bool worldPositionStay = true)
+		internal static TBehaviour InstantiateResource<TBehaviour>(string path, GameObject parent, bool worldPositionStay = true)
 			where TBehaviour : MonoBehaviour
 		{
 			var loadedBehaviour = Resources.Load<TBehaviour>(path);
-			var behaviour = Object.Instantiate(loadedBehaviour, parent, worldPositionStay);
+			var behaviour = Object.Instantiate(loadedBehaviour, parent.transform, worldPositionStay);
 			behaviour.name = loadedBehaviour.name;
 			return behaviour;
 		}

--- a/Utils.cs
+++ b/Utils.cs
@@ -35,7 +35,7 @@ namespace DUCK.HieriarchyBehaviour
 
 		internal static void DestroyChild(GameObject parent, MonoBehaviour child)
 		{
-			if (child.transform.parent != parent)
+			if (child.transform.parent != parent.transform)
 			{
 				throw new ArgumentException(string.Format("{0} is not a child transform of {1}", child.name, parent.name));
 			}

--- a/Utils.cs.meta
+++ b/Utils.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d31762d28c8f74a5ca7996a534a3836a
+timeCreated: 1528196766
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Requirements: 
* Core Features ✅
* Documentation
* Read me
* Tests

## What is it?
Its a collection of GameObject extension methods to allow for runtime instantiation of MonoBehaviours that include an Initialize method that takes type-safe arguments.


## What are the Core Features?
- CreateChild
- CreateChildFromResources
- CreateChildFromLoaded (both loaded and instantiated)
- Replace

## Why does it exist?
The idea is to create something that has a similar functionality to `AbstractController` but reduce the ability to create code smells and bad practices.

AbstractController had both pros and cons, but it started to feel like it gained more cons than pros.
**Cons**
- Parent is exposed
- Misleading names
- Inheritance
- Desync of controller graph to the scene graph
- Initialize args are not type safe
- The StateMachine system with its AbstractStateController class

**Pros**
- Hierarchy
- Initialize with args
- StateMachine

I have taken the pros from `AbstractController` and created a system around them that doesn't include the cons.

- There is no longer a need for referencing a parent object. Once the child is created its only tied to its parent via the scene hierarchy.
- The naming no longer hints at the MVC pattern and is learning more towards Scene Hierarchy and MonoBehaviours.
- It uses interfaces rather than inheriting from an abstract class so you create your mono behaviours and simply implement the `IHeirarchyBehaviour` interface when wanted.
- There is no tracking of child objects in code, its purely done via the scene hierarchy so no desyncs can occur.
- Using templatization in the interface allows for type-safe args in the Initialize methods.
- The extension method Replace gives the ability to destroy a MonoBehaviour, then create a new `IHeirarchyBehaviour` to return, giving a similar use as the StateMachine.

One thing AbstractController had that HierarchyBehaviour doesn't have is a Destroy method to complete the life cycle. This is because MonoBehaviour supplies an `OnDestroy` that should be used instead.

## How to use it.
HierarchyBehaviour is entirely run via `GameObject` Extension methods for creation and interfaces for implementation.

```c#
public class MyClass : MonoBehaviour, IHierarchyBehaviour
{
    public void Initialize()
    {
        Debug.Log("Initialized");
    }
}
```
```c#
public class MyClass : MonoBehaviour, IHierarchyBehaviour<CustomArgs>
{
    public void Initialize(CustomArgs args)
    {
        Debug.Log("Initialized with " + args);
    }
}
```

The Initialize methods are automatically called by the GameObjectExtention methods used to create the new instance.

However you can just add your class that implements `IHierarchyBehaviour` and choose to call Initialize when you prefer to.

### CreateChild
With Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild<ExtendedFromMonoBehaviour, CustomArgs>(new CustomArgs("HelloWorld"));
```
Without Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild<ExtendedFromMonoBehaviour>();
```

This will create a child new GameObject and apply the template class `TBehaviour`.  
The template class must extend MonoBehaviour and implement `IHierarchyBehaviour` or `IHierarchyBehaviour<TArgs>`.
This will return the new instance of `TBehaviour`.

### CreateChild from resources
With Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild<ExtendedFromMonoBehaviour, CustomArgs>("MyResourcePath", new CustomArgs("HelloWorld"));
```
Without Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild<ExtendedFromMonoBehaviour>("MyResourcePath");
```

This will load and instantiate a asset of type `TBehaviour` from Unity's `Resources`.
The template class must extend MonoBehaviour and implement `IHierarchyBehaviour` or `IHierarchyBehaviour<TArgs>`. 
This will return the new instance of `TBehaviour`.

### CreateChild from loaded
With Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild(myCustomMonoBehaviourPrefab, new CustomArgs("HelloWorld"));
```
Without Arguements
```C#
var myCustomMonoBehaviour = gameObject.CreateChild(myCustomMonoBehaviourPrefab);
```

This will take a pre-existing (loaded or instantiated) `IHierarchyBehaviour` and clone it. The template class must extend MonoBehaviour and implement `IHierarchyBehaviour` or `IHierarchyBehaviour<TArgs>`. 
This will return the new instance of `TBehaviour`.


### ReplaceChild
With Arguements
```C#
var myCustomMonoBehaviour = gameObject.ReplaceChild<ExtendedFromMonoBehaviour, CustomArgs>(myOtherCustomMonoBehaviour, new CustomArgs("HelloWorld"));
```
Without Arguements
```C#
var myCustomMonoBehaviour = gameObject.ReplaceChild<ExtendedFromMonoBehaviour>(myOtherCustomMonoBehaviour);
```

You can also use ReplaceChild with resourced assets and loaded assets.
```C#
var myCustomMonoBehaviour = gameObject.ReplaceChild<ExtendedFromMonoBehaviour>(myOtherCustomMonoBehaviour, "MyResourcePath");
```
```C#
var myCustomMonoBehaviour = gameObject.ReplaceChild<ExtendedFromMonoBehaviour>(myOtherCustomMonoBehaviour,  myCustomMonoBehaviourPrefab);
```

ReplaceChild requires a `TBehaviour` to create or instantiate and an existing MonoBehaviour to Destroy.
The template class must extend MonoBehaviour and implement `IHierarchyBehaviour` or `IHierarchyBehaviour<TArgs>`. 
This will return the new instance of `TBehaviour`.  