### PR TITLE
CreateChild GameObject

### DIFF
--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -5,22 +5,48 @@ namespace DUCK.HieriarchyBehaviour
 	public static class GameObjectExtensions
 	{
 		/// <summary>
+		/// Creates a clone of the given GameObject as a child transform.
+		/// </summary>
+		/// <param name="toClone">The GameObject to clone.</param>
+		/// <returns>The new GameObject</returns>
+		public static GameObject CreateChild(this GameObject parent, GameObject toClone)
+		{
+			return Utils.CloneGameObject(toClone, parent);
+		}
+
+		/// <summary>
+		/// Creates a child GameObject from resources.
+		/// </summary>
+		/// <param name="path">The path to the resourced asset.</param>
+		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
+		/// <returns>The new GameObject</returns>
+		public static GameObject CreateChild(this GameObject parent, string path, bool worldPositionStays = true)
+		{
+			return Utils.InstantiateResource<GameObject>(path, parent, worldPositionStays);
+		}
+
+		/// <summary>
 		/// Creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized automatically and returned.
+		/// IHierarchyBehaviours's will be initialized.
 		/// </summary>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new child GameObject.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(parent);
-			behaviour.Initialize();
+			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
+			if (hierarchyBehaviour != null)
+			{
+				hierarchyBehaviour.Initialize();
+			}
+
 			return behaviour;
 		}
 
 		/// <summary>
 		/// Creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new child GameObject.</typeparam>
@@ -35,24 +61,29 @@ namespace DUCK.HieriarchyBehaviour
 		}
 
 		/// <summary>
-		/// Creates a child GameObject, by loading from resources and instantiating.
-		/// TBehaviour will be initialized automatically and returned.
+		/// Creates a child GameObject from resources.
+		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new GameObject.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, string path, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = Utils.InstantiateResource<TBehaviour>(path, parent, worldPositionStays);
-			behaviour.Initialize();
+			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
+			if (hierarchyBehaviour != null)
+			{
+				hierarchyBehaviour.Initialize();
+			}
+
 			return behaviour;
 		}
 
 		/// <summary>
-		/// Creates a child GameObject, by loading from resources and instantiating.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// Creates a child GameObject from resources.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
@@ -70,22 +101,27 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized automatically and returned.
+		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="toClone">The GameObject to clone.</param>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour that is being cloned.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, TBehaviour toClone)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = Utils.CloneBehaviour(toClone, parent);
-			behaviour.Initialize();
+			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
+			if (hierarchyBehaviour != null)
+			{
+				hierarchyBehaviour.Initialize();
+			}
+
 			return behaviour;
 		}
 
 		/// <summary>
 		/// Creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="toClone">The GameObject to clone.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
@@ -102,13 +138,13 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized automatically and returned.
+		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour>();
@@ -116,7 +152,7 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
@@ -132,7 +168,7 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a child GameObject, by loading from resources and instantiating.
-		/// TBehaviour will be initialized automatically and returned.
+		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <param name="path">The path to the resourced asset.</param>
@@ -140,7 +176,7 @@ namespace DUCK.HieriarchyBehaviour
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild<TBehaviour>(path, worldPositionStays);
@@ -148,7 +184,7 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a child GameObject, by loading from resources and instantiating.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <param name="path">The path to the resourced asset.</param>
@@ -166,14 +202,14 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized automatically and returned.
+		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <param name="toClone">The GameObject to clone.</param>
 		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
 		/// <returns>The new TBehaviour</returns>
 		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour
+			where TBehaviour : MonoBehaviour
 		{
 			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild(toClone);
@@ -181,7 +217,7 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Destroys the child MonoBehaviour and creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized with the given arguements automatically and returned.
+		/// TBehaviour will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
 		/// <param name="toClone">The GameObject to clone.</param>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Without Arguements
 ```C#
 var myClass = gameObject.CreateChild<MyClass>("MyResourcePath");
 ```
+GameObject
+```C#
+var myGameObject = gameObject.CreateChild(path: "MyResourcePath");
+```
 
 This will create a child new GameObject and adds the component specified by the `TBehaviour` type parameter.
 The type parameter must extend MonoBehaviour and implement `IHierarchyBehaviour` or `IHierarchyBehaviour<TArgs>`.
@@ -79,6 +83,10 @@ var myClassWithArgs = gameObject.CreateChild<MyClassWithArgs>(prefab, new Custom
 Without Arguements
 ```C#
 var myClass = gameObject.CreateChild<MyClass>(prefab);
+```
+GameObject
+```C#
+   var myGameObject = gameObject.CreateChild(prefab.gameObject);
 ```
 
 This will take a pre-existing (loaded or instantiated) `IHierarchyBehaviour` and clone it.  

--- a/Tests/GameObjectExtensions.cs
+++ b/Tests/GameObjectExtensions.cs
@@ -85,6 +85,22 @@ namespace DUCK.HieriarchyBehaviour
 		}
 
 		[Test]
+		public void Expect_CreateChild_GameObject_AsChild()
+		{
+			var toClone = new GameObject("GameObject To Clone");
+			toClone.transform.SetParent(root.transform);
+			var gameObject = root.gameObject.CreateChild(toClone);
+			Assert.AreEqual(root.transform, gameObject.transform.parent);
+		}
+
+		[Test]
+		public void Expect_CreateChild_GameObject_FromResources_AsChild()
+		{
+			var gameObject = root.gameObject.CreateChild(path: PREFAB_WITHOUT_ARGS_RESOURCE_PATH);
+			Assert.AreEqual(root.transform, gameObject.transform.parent);
+		}
+
+		[Test]
 		public void Expect_CreateChild_New_ToInitialize()
 		{
 			var behaviour = root.gameObject.CreateChild<HierarchyBehaviour>();

--- a/Utils.cs
+++ b/Utils.cs
@@ -6,7 +6,15 @@ namespace DUCK.HieriarchyBehaviour
 {
 	internal static class Utils
 	{
-		internal static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, GameObject parent)
+		public static GameObject CloneGameObject(GameObject gameObjectToClone, GameObject parent)
+		{
+			var gameObject = Object.Instantiate(gameObjectToClone, parent.transform);
+			gameObject.name = gameObjectToClone.name;
+			gameObject.transform.localPosition = Vector3.zero;
+			return gameObject;
+		}
+
+		public static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, GameObject parent)
 			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = Object.Instantiate(behaviourToClone, parent.transform);
@@ -15,7 +23,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		internal static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(GameObject parent)
+		public static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(GameObject parent)
 			where TBehaviour : MonoBehaviour
 		{
 			var behaviour = new GameObject(typeof(TBehaviour).Name).AddComponent<TBehaviour>();
@@ -24,16 +32,16 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		internal static TBehaviour InstantiateResource<TBehaviour>(string path, GameObject parent, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour
+		public static TObject InstantiateResource<TObject>(string path, GameObject parent, bool worldPositionStays = true) 
+			where TObject : Object
 		{
-			var loadedBehaviour = Resources.Load<TBehaviour>(path);
+			var loadedBehaviour = Resources.Load<TObject>(path);
 			var behaviour = Object.Instantiate(loadedBehaviour, parent.transform, worldPositionStays);
 			behaviour.name = loadedBehaviour.name;
 			return behaviour;
 		}
 
-		internal static void DestroyChild(GameObject parent, MonoBehaviour child)
+		public static void DestroyChild(GameObject parent, MonoBehaviour child)
 		{
 			if (child.transform.parent != parent.transform)
 			{


### PR DESCRIPTION
CreateChild is no longer bound to `IHierarchyBehaviours`, you can now CreateChild GameObject or MonoBehaviour that doesn't implement `IHierarchyBehaviour`.

I've created two new CreateChild overload methods that deal with only GameObjects.
Also, I have modified the existing CreateChild overloads to only call `Initialize()` if its of type `IHierarhyBehaviour`.

Tests have been added and the readme updated.

All tests succeed: <img width="107" alt="screen shot 2018-06-19 at 13 44 42" src="https://user-images.githubusercontent.com/33153909/41598036-f9bb8f78-73c6-11e8-90be-62c5672a88b4.png">
