### PR TITLE
Replaced MonoBehaviour with Components

### DIFF
--- a/GameObjectExtensions.cs
+++ b/GameObjectExtensions.cs
@@ -26,15 +26,15 @@ namespace DUCK.HieriarchyBehaviour
 		}
 
 		/// <summary>
-		/// Creates a child GameObject with the given TBehaviour component.
+		/// Creates a child GameObject with the given TComponent component.
 		/// IHierarchyBehaviours's will be initialized.
 		/// </summary>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new child GameObject.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent)
-			where TBehaviour : MonoBehaviour
+		/// <typeparam name="TComponent">The type of Component to be added to the new child GameObject.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent>(this GameObject parent)
+			where TComponent : Component
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(parent);
+			var behaviour = Utils.CreateGameObjectWithComponent<TComponent>(parent);
 			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
 			if (hierarchyBehaviour != null)
 			{
@@ -45,17 +45,17 @@ namespace DUCK.HieriarchyBehaviour
 		}
 
 		/// <summary>
-		/// Creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized with the given arguements.
+		/// Creates a child GameObject with the given TComponent component.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new child GameObject.</typeparam>
+		/// <typeparam name="TComponent">The type of Component to be added to the new child GameObject.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TArgs args)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent, TArgs>(this GameObject parent, TArgs args)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CreateGameObjectWithBehaviour<TBehaviour>(parent);
+			var behaviour = Utils.CreateGameObjectWithComponent<TComponent>(parent);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
@@ -66,12 +66,12 @@ namespace DUCK.HieriarchyBehaviour
 		/// </summary>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new GameObject.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, string path, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour
+		/// <typeparam name="TComponent">The type of Component to be added to the new GameObject.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent>(this GameObject parent, string path, bool worldPositionStays = true)
+			where TComponent : Component
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, parent, worldPositionStays);
+			var behaviour = Utils.InstantiateResource<TComponent>(path, parent, worldPositionStays);
 			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
 			if (hierarchyBehaviour != null)
 			{
@@ -83,33 +83,33 @@ namespace DUCK.HieriarchyBehaviour
 
 		/// <summary>
 		/// Creates a child GameObject from resources.
-		/// TBehaviour will be initialized with the given arguements.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
 		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be added to the new GameObject.</typeparam>
+		/// <typeparam name="TComponent">The type of Component to be added to the new GameObject.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, string path, TArgs args, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent, TArgs>(this GameObject parent, string path, TArgs args, bool worldPositionStays = true)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.InstantiateResource<TBehaviour>(path, parent, worldPositionStays);
+			var behaviour = Utils.InstantiateResource<TComponent>(path, parent, worldPositionStays);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
 
 		/// <summary>
-		/// Creates a clone of the given TBehaviour as a child transform.
+		/// Creates a clone of the given TComponent as a child transform.
 		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
 		/// <param name="toClone">The GameObject to clone.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour that is being cloned.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour>(this GameObject parent, TBehaviour toClone)
-			where TBehaviour : MonoBehaviour
+		/// <typeparam name="TComponent">The type of Component that is being cloned.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent>(this GameObject parent, TComponent toClone)
+			where TComponent : Component
 		{
-			var behaviour = Utils.CloneBehaviour(toClone, parent);
+			var behaviour = Utils.CloneComponent(toClone, parent);
 			var hierarchyBehaviour = behaviour as IHierarchyBehaviour;
 			if (hierarchyBehaviour != null)
 			{
@@ -120,113 +120,113 @@ namespace DUCK.HieriarchyBehaviour
 		}
 
 		/// <summary>
-		/// Creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized with the given arguements.
+		/// Creates a clone of the given TComponent as a child transform.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
 		/// <param name="toClone">The GameObject to clone.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour that is being cloned.</typeparam>
+		/// <typeparam name="TComponent">The type of Component that is being cloned.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour CreateChild<TBehaviour, TArgs>(this GameObject parent, TBehaviour toClone, TArgs args)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent CreateChild<TComponent, TArgs>(this GameObject parent, TComponent toClone, TArgs args)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
-			var behaviour = Utils.CloneBehaviour(toClone, parent);
+			var behaviour = Utils.CloneComponent(toClone, parent);
 			behaviour.Initialize(args);
 			return behaviour;
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a child GameObject with the given TBehaviour component.
+		/// Destroys the child GameObject and creates a new child GameObject with the given TComponent component.
 		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy)
-			where TBehaviour : MonoBehaviour
+		/// <param name="toDestroy">The child Component to destroy.</param>
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent>(this GameObject parent, Component toDestroy)
+			where TComponent : Component
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour>();
+			return parent.CreateChild<TComponent>();
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a child GameObject with the given TBehaviour component.
-		/// TBehaviour will be initialized with the given arguements.
+		/// Destroys the child GameObject and creates a new child GameObject with the given TComponent component.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
+		/// <param name="toDestroy">The child Component to destroy.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TArgs args)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent, TArgs>(this GameObject parent, Component toDestroy, TArgs args)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour, TArgs>(args);
+			return parent.CreateChild<TComponent, TArgs>(args);
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a child GameObject, by loading from resources and instantiating.
+		/// Destroys the child GameObject and creates a new child GameObject, by loading from resources and instantiating.
 		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
+		/// <param name="toDestroy">The child Component to destroy.</param>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, string path, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent>(this GameObject parent, Component toDestroy, string path, bool worldPositionStays = true)
+			where TComponent : Component
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour>(path, worldPositionStays);
+			return parent.CreateChild<TComponent>(path, worldPositionStays);
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a child GameObject, by loading from resources and instantiating.
-		/// TBehaviour will be initialized with the given arguements.
+		/// Destroys the child GameObject and creates a new child GameObject, by loading from resources and instantiating.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
+		/// <param name="toDestroy">The child Component to destroy.</param>
 		/// <param name="path">The path to the resourced asset.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
 		/// <param name="worldPositionStays">Will the instantiated GameObject stay in its world position or be set to local origin.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, string path, TArgs args, bool worldPositionStays = true)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent, TArgs>(this GameObject parent, Component toDestroy, string path, TArgs args, bool worldPositionStays = true)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
 			Utils.DestroyChild(parent, toDestroy);
-			return parent.CreateChild<TBehaviour, TArgs>(path, args, worldPositionStays);
+			return parent.CreateChild<TComponent, TArgs>(path, args, worldPositionStays);
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a clone of the given TBehaviour as a child transform.
+		/// Destroys the child GameObject and creates a clone of the given TComponent as a child transform.
 		/// IHierarchyBehaviour's will be initialized.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
+		/// <param name="toDestroy">The child Component to destroy.</param>
 		/// <param name="toClone">The GameObject to clone.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone)
-			where TBehaviour : MonoBehaviour
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent>(this GameObject parent, Component toDestroy, TComponent toClone)
+			where TComponent : Component
 		{
 			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild(toClone);
 		}
 
 		/// <summary>
-		/// Destroys the child MonoBehaviour and creates a clone of the given TBehaviour as a child transform.
-		/// TBehaviour will be initialized with the given arguements.
+		/// Destroys the child GameObject and creates a clone of the given TComponent as a child transform.
+		/// TComponent will be initialized with the given arguements.
 		/// </summary>
-		/// <param name="toDestroy">The child MonoBehaviour to destroy.</param>
+		/// <param name="toDestroy">The child Component to destroy.</param>
 		/// <param name="toClone">The GameObject to clone.</param>
 		/// <param name="args">The TArgs object to be passed in on initialization.</param>
-		/// <typeparam name="TBehaviour">The type of MonoBehaviour to be created.</typeparam>
+		/// <typeparam name="TComponent">The type of Component to be created.</typeparam>
 		/// <typeparam name="TArgs">The type of arguements to be given on initialization.</typeparam>
-		/// <returns>The new TBehaviour</returns>
-		public static TBehaviour ReplaceChild<TBehaviour, TArgs>(this GameObject parent, MonoBehaviour toDestroy, TBehaviour toClone, TArgs args)
-			where TBehaviour : MonoBehaviour, IHierarchyBehaviour<TArgs>
+		/// <returns>The new TComponent</returns>
+		public static TComponent ReplaceChild<TComponent, TArgs>(this GameObject parent, Component toDestroy, TComponent toClone, TArgs args)
+			where TComponent : Component, IHierarchyBehaviour<TArgs>
 		{
 			Utils.DestroyChild(parent, toDestroy);
 			return parent.CreateChild(toClone, args);

--- a/TestBehaviours.meta
+++ b/TestBehaviours.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28409ecd4d2334aafa9a55709d72e1f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestBehaviours/HierarchyBehaviour.cs
+++ b/TestBehaviours/HierarchyBehaviour.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace DUCK.HieriarchyBehaviour.TestBehaviours
+{
+	[AddComponentMenu("")]
+	public class HierarchyBehaviour : MonoBehaviour, IHierarchyBehaviour
+	{
+		public bool DidInitialize { get; private set; }
+
+		public void Initialize()
+		{
+			DidInitialize = true;
+		}
+	}
+}

--- a/TestBehaviours/HierarchyBehaviour.cs.meta
+++ b/TestBehaviours/HierarchyBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71528217e3a004e79bdc063568093674
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestBehaviours/HierarchyBehaviourWithArgs.cs
+++ b/TestBehaviours/HierarchyBehaviourWithArgs.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+
+namespace DUCK.HieriarchyBehaviour.TestBehaviours
+{
+	[AddComponentMenu("")]
+	public class HierarchyBehaviourWithArgs : MonoBehaviour, IHierarchyBehaviour<string>
+	{
+		public string Args { get; private set; }
+		public bool DidInitialize { get; private set; }
+
+		public void Initialize(string args)
+		{
+			DidInitialize = true;
+			Args = args;
+		}
+	}
+}

--- a/TestBehaviours/HierarchyBehaviourWithArgs.cs.meta
+++ b/TestBehaviours/HierarchyBehaviourWithArgs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ffdf1e6d0e8646429809555170c184b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestBehaviours/TestBehaviours.asmdef
+++ b/TestBehaviours/TestBehaviours.asmdef
@@ -1,12 +1,9 @@
 {
-    "name": "DUCK.HierarchyBehaviour.Tests",
+    "name": "DUCK.HierarchyBehaviour.TestBehaviours",
     "references": [
-        "DUCK.HierarchyBehaviour.TestBehaviours",
         "HierarchyBehaviour"
     ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
-    ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],

--- a/TestBehaviours/TestBehaviours.asmdef.meta
+++ b/TestBehaviours/TestBehaviours.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0f865591f28c8457e822f44b2e6b2003
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/GameObjectExtensions.cs
+++ b/Tests/GameObjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using DUCK.HieriarchyBehaviour.TestBehaviours;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -12,28 +13,6 @@ namespace DUCK.HieriarchyBehaviour
 		private const string PREFAB_WITHOUT_ARGS_RESOURCE_PATH = "PrefabWithoutArgs";
 		private const string PREFAB_WITH_ARGS_RESOURCE_PATH = "PrefabWithArgs";
 		private const string RESOURCE_PATH = "/Resources/";
-
-		private class HierarchyBehaviourWithArgs : MonoBehaviour, IHierarchyBehaviour<string>
-		{
-			public string Args { get; private set; }
-			public bool DidInitialize { get; private set; }
-
-			public void Initialize(string args)
-			{
-				DidInitialize = true;
-				Args = args;
-			}
-		}
-
-		private class HierarchyBehaviour : MonoBehaviour, IHierarchyBehaviour
-		{
-			public bool DidInitialize { get; private set; }
-
-			public void Initialize()
-			{
-				DidInitialize = true;
-			}
-		}
 
 		private HierarchyBehaviour root;
 		private HierarchyBehaviour prefabBehaviour;
@@ -69,16 +48,16 @@ namespace DUCK.HieriarchyBehaviour
 
 			var prefabWithoutArgsPath = Application.dataPath + RESOURCE_PATH + PREFAB_WITHOUT_ARGS_RESOURCE_PATH + ".prefab";
 			File.Delete(prefabWithoutArgsPath);
-			File.Delete(prefabWithoutArgsPath + ".prefab.meta");
+			File.Delete(prefabWithoutArgsPath + ".meta");
 			var prefabWithArgsPath = Application.dataPath + RESOURCE_PATH + PREFAB_WITH_ARGS_RESOURCE_PATH + ".prefab";
 			File.Delete(prefabWithArgsPath);
-			File.Delete(prefabWithArgsPath + ".prefab.meta");
+			File.Delete(prefabWithArgsPath + ".meta");
 			AssetDatabase.Refresh();
 
 			if (!didResourcesExist)
 			{
 				Directory.Delete(Application.dataPath + RESOURCE_PATH);
-				File.Delete(Application.dataPath + "Resources.meta");
+				File.Delete(Application.dataPath + "/Resources.meta");
 			}
 
 			AssetDatabase.Refresh();

--- a/Utils.cs
+++ b/Utils.cs
@@ -14,25 +14,25 @@ namespace DUCK.HieriarchyBehaviour
 			return gameObject;
 		}
 
-		public static TBehaviour CloneBehaviour<TBehaviour>(TBehaviour behaviourToClone, GameObject parent)
-			where TBehaviour : MonoBehaviour
+		public static TComponent CloneComponent<TComponent>(TComponent componentToClone, GameObject parent)
+			where TComponent : Component
 		{
-			var behaviour = Object.Instantiate(behaviourToClone, parent.transform);
-			behaviour.name = behaviourToClone.name;
-			behaviour.transform.localPosition = Vector3.zero;
-			return behaviour;
+			var component = Object.Instantiate(componentToClone, parent.transform);
+			component.name = componentToClone.name;
+			component.transform.localPosition = Vector3.zero;
+			return component;
 		}
 
-		public static TBehaviour CreateGameObjectWithBehaviour<TBehaviour>(GameObject parent)
-			where TBehaviour : MonoBehaviour
+		public static TComponent CreateGameObjectWithComponent<TComponent>(GameObject parent)
+			where TComponent : Component
 		{
-			var behaviour = new GameObject(typeof(TBehaviour).Name).AddComponent<TBehaviour>();
-			behaviour.transform.SetParent(parent.transform);
-			behaviour.transform.localPosition = Vector3.zero;
-			return behaviour;
+			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
+			component.transform.SetParent(parent.transform);
+			component.transform.localPosition = Vector3.zero;
+			return component;
 		}
 
-		public static TObject InstantiateResource<TObject>(string path, GameObject parent, bool worldPositionStays = true) 
+		public static TObject InstantiateResource<TObject>(string path, GameObject parent, bool worldPositionStays = true)
 			where TObject : Object
 		{
 			var loadedBehaviour = Resources.Load<TObject>(path);
@@ -41,7 +41,7 @@ namespace DUCK.HieriarchyBehaviour
 			return behaviour;
 		}
 
-		public static void DestroyChild(GameObject parent, MonoBehaviour child)
+		public static void DestroyChild(GameObject parent, Component child)
 		{
 			if (child.transform.parent != parent.transform)
 			{


### PR DESCRIPTION
In order to use CreateChild and ReplaceChild with Unity components (e.g Camera, Light, etc) I have switch `MonoBehaviour` for `Component`.
 All MonoBehaviours still work as they derive from component: `MonoBehaviour : Behaviour : Component`

example:
```c#
gameObject.CreateChild<Light>();
```

During testing in 2018.2 I found that you can no longer create a prefab from a MonoBehaviour that doesn't have a filename matching it due to missing GUID references. This means I needed to make the testing behaviours as an independent file. These Behaviours cannot be inside the Tests assembly due to a `TestAssembly` being Editor only, which `MonoBehaviours` are not. So for testing I have to create another Assembly under `DUCK.HierarchyBehaviour.TestBehaviours` that is only used by the Test Assembly.

All tests pass.