### PR TITLE
CreateChild with name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ lightEstimation.Initalize(directionalLight, pointLight);
 ```
 
 ### CreateChild
+
+With Name
+```C#
+var myGameObject = gameObject.CreateChild("HelloWorld");
+```
+Without Name
+```C#
+var myGameObject = gameObject.CreateChild();
+```
+
 With Arguements
 ```C#
 var myClassWithArgs = gameObject.CreateChild<MyClassWithArgs, CustomArgs>(new CustomArgs("HelloWorld"));

--- a/Scripts/GameObjectExtensions.cs
+++ b/Scripts/GameObjectExtensions.cs
@@ -5,6 +5,16 @@ namespace Duck.HieriarchyBehaviour
 	public static class GameObjectExtensions
 	{
 		/// <summary>
+		/// Creates a new GameObject as a child transform.
+		/// </summary>
+		/// <param name="name">The desired GameObject name</param>
+		/// <returns>The new GameObject</returns>
+		public static GameObject CreateChild(this GameObject parent, string name)
+		{
+			return Utils.CreateChildGameObject(parent, name);
+		}
+
+		/// <summary>
 		/// Creates a clone of the given GameObject as a child transform.
 		/// </summary>
 		/// <param name="toClone">The GameObject to clone.</param>

--- a/Scripts/GameObjectExtensions.cs
+++ b/Scripts/GameObjectExtensions.cs
@@ -9,7 +9,7 @@ namespace Duck.HieriarchyBehaviour
 		/// </summary>
 		/// <param name="name">The desired GameObject name</param>
 		/// <returns>The new GameObject</returns>
-		public static GameObject CreateChild(this GameObject parent, string name)
+		public static GameObject CreateChild(this GameObject parent, string name = "GameObject")
 		{
 			return Utils.CreateChildGameObject(parent, name);
 		}

--- a/Scripts/Utils.cs
+++ b/Scripts/Utils.cs
@@ -6,6 +6,13 @@ namespace Duck.HieriarchyBehaviour
 {
 	internal static class Utils
 	{
+		public static GameObject CreateChildGameObject(GameObject parent, string name)
+		{
+			var gameObject = new GameObject(name);
+			gameObject.transform.SetParent(parent.transform);
+			return gameObject;
+		}
+
 		public static GameObject CloneGameObject(GameObject gameObjectToClone, GameObject parent)
 		{
 			var gameObject = Object.Instantiate(gameObjectToClone, parent.transform);

--- a/Tests/GameObjectExtensions.cs
+++ b/Tests/GameObjectExtensions.cs
@@ -64,6 +64,16 @@ namespace Duck.HieriarchyBehaviour.Tests
 		}
 
 		[Test]
+		public void Expect_CreateChild_GameObject_With_Name_AsChild()
+		{
+			const string GAME_OBJECT_NAME = "Test Name";
+			var gameObject = root.gameObject.CreateChild(GAME_OBJECT_NAME);
+			Assert.IsNotNull(gameObject);
+			Assert.AreEqual(GAME_OBJECT_NAME, gameObject.name);
+			Assert.AreEqual(root.transform, gameObject.transform.parent);
+		}
+
+		[Test]
 		public void Expect_CreateChild_GameObject_AsChild()
 		{
 			var toClone = new GameObject("GameObject To Clone");

--- a/Tests/GameObjectExtensions.cs
+++ b/Tests/GameObjectExtensions.cs
@@ -64,7 +64,7 @@ namespace Duck.HieriarchyBehaviour.Tests
 		}
 
 		[Test]
-		public void Expect_CreateChild_GameObject()
+		public void Expect_CreateChild_GameObject_AsChild()
 		{
 			var gameObject = root.gameObject.CreateChild();
 			Assert.IsNotNull(gameObject);
@@ -82,7 +82,7 @@ namespace Duck.HieriarchyBehaviour.Tests
 		}
 
 		[Test]
-		public void Expect_CreateChild_GameObject_AsChild()
+		public void Expect_CreateChild_Cloned_GameObject_AsChild()
 		{
 			var toClone = new GameObject("GameObject To Clone");
 			toClone.transform.SetParent(root.transform);

--- a/Tests/GameObjectExtensions.cs
+++ b/Tests/GameObjectExtensions.cs
@@ -64,6 +64,14 @@ namespace Duck.HieriarchyBehaviour.Tests
 		}
 
 		[Test]
+		public void Expect_CreateChild_GameObject()
+		{
+			var gameObject = root.gameObject.CreateChild();
+			Assert.IsNotNull(gameObject);
+			Assert.AreEqual(root.transform, gameObject.transform.parent);
+		}
+
+		[Test]
 		public void Expect_CreateChild_GameObject_With_Name_AsChild()
 		{
 			const string GAME_OBJECT_NAME = "Test Name";


### PR DESCRIPTION
New API for CreateChild. You can now create a child gameobject that doesn't have any components as a child of another gameObject. An optional parameter for the name is also included.

API:
```c#
var myGameObject = gameObject.CreateChild();
```
```c#
var myGameObject = gameObject.CreateChild("HelloWorld");
```
Would replace the less DRY way of:
```c#
var myGameObject = new GameObject("HelloWorld");
gameObject.transform.SetParent(gameObject.transform);
```

Tests added.
All tests succeed.
<img width="109" alt="screenshot 2019-01-15 at 14 49 36" src="https://user-images.githubusercontent.com/33153909/51187929-cd6b3780-18d4-11e9-9db8-d10341996533.png">

Readme updated with latest API
